### PR TITLE
Fixed to use parameter '--user' if directive is pip

### DIFF
--- a/pip.py
+++ b/pip.py
@@ -95,9 +95,12 @@ class Brew(dotbot.Plugin):
     def _handle_install(self, directive, data):
         binary = self._get_binary(directive, data)
         requirements = self._prepare_requirements(directive, data)
+        param = ''
+        if directive != self._pipsi_directive:
+            param = '--user'
 
         for req in requirements:
-            command = '{} install {}'.format(binary, req)
+            command = '{} install {} {}'.format(binary, param, req)
 
             with open(os.devnull, 'w') as devnull:
                 result = subprocess.call(


### PR DESCRIPTION
Hi Nikita, I have started using your plugin on my Linux environment, but I was having difficulty to install packages without `sudo`.
Then I made this little patch to use the parameter `--user` in pip if is it, to install packages under de user home directory.

I am not fluent in python, I would like your feedback if there is a better way to do it