### PR TITLE
Feature: optionally display stdout stderr and use --user parameter

### DIFF
--- a/example.yaml
+++ b/example.yaml
@@ -1,6 +1,10 @@
 - pip:
     file: requirements.txt
     binary: /usr/local/bin/pip3
-
+    user: true
+    stdout: false
+    stderr: true
 - pipsi:
     file: requirements-pipsi.txt
+    stdout: true
+    stderr: false


### PR DESCRIPTION
To improve the possibility of debugging I implemented these optional parameters.

For pip & pipsi:
```
stdout: false
stderr: true
```
Only for pip:
`user: true` - use `--user` parameter in pip install