### PR TITLE
Allow setting binaries for pipx and pipsi

### DIFF
--- a/pip.py
+++ b/pip.py
@@ -62,14 +62,11 @@ class Brew(dotbot.Plugin):
     def _get_binary(self, directive, data):
         """
         Return correct binary path.
-
-        Respects `binary` key for `pip`.
-        Returns just `pipsi` for `pipsi`.
         """
-        if directive in [self._pipsi_directive, self._pipx_directive]:
-            return directive
+        if data.get('binary', False):
+            return data.get('binary')
 
-        return data.get('binary', self._default_binary)
+        return directive
 
     def _prepare_requirements(self, directive, data):
         """


### PR DESCRIPTION
I see no reason why we shouldn't be allowed to set the binary file for pipx and pipsi as well as pip. This allows using pip to install pipx, and then using pipx without modifying the PATH variable of the parent shell.